### PR TITLE
Move type validation to constructors for gtxn and gitxn variants

### DIFF
--- a/pyteal/ast/gitxn.py
+++ b/pyteal/ast/gitxn.py
@@ -17,18 +17,16 @@ class GitxnExpr(TxnExpr):
 
     def __init__(self, txnIndex: int, field: TxnField) -> None:
         super().__init__(Op.gitxn, "Gitxn", field)
-        self.txnIndex = txnIndex
 
-        def validate_types_or_throw():
-            # currently we do not have gitxns, only gitxn with immediate transaction index supported
-            if type(self.txnIndex) is not int:
-                raise TealInputError(
-                    "Invalid gitxn syntax with immediate transaction field {} and transaction index {}".format(
-                        self.field, self.txnIndex
-                    )
+        # Currently we do not have gitxns. Only gitxn with immediate transaction index supported.
+        if type(txnIndex) is not int:
+            raise TealInputError(
+                "Invalid gitxn syntax with immediate transaction field {} and transaction index {}".format(
+                    field, txnIndex
                 )
+            )
 
-        validate_types_or_throw()
+        self.txnIndex = txnIndex
 
     def __str__(self):
         return "({} {} {})".format(self.name, self.txnIndex, self.field.arg_name)

--- a/pyteal/ast/gitxn.py
+++ b/pyteal/ast/gitxn.py
@@ -53,22 +53,13 @@ class GitxnaExpr(TxnaExpr):
 
     def __init__(self, txnIndex: int, field: TxnField, index: Union[int, Expr]) -> None:
         super().__init__(Op.gitxna, Op.gitxnas, "Gitxna", field, index)
+
+        if type(txnIndex) is not int:
+            raise TealInputError(
+                f"Invalid txnIndex type:  Expected int, but received {txnIndex}."
+            )
+
         self.txnIndex = txnIndex
-
-        def validate_types_or_throw():
-            is_index_expr = isinstance(self.index, Expr)
-            if type(self.txnIndex) is not int or not (
-                type(self.index) is int or is_index_expr
-            ):
-                raise TealInputError(
-                    "Invalid gitxna syntax with immediate transaction index {}, transaction field {}, array index {}".format(
-                        self.txnIndex, self.field, self.index
-                    )
-                )
-            if is_index_expr:
-                require_type(index, TealType.uint64)
-
-        validate_types_or_throw()
 
     def __str__(self):
         return "({} {} {} {})".format(

--- a/pyteal/ast/gitxn_test.py
+++ b/pyteal/ast/gitxn_test.py
@@ -53,7 +53,7 @@ def test_gitxna_expr_invalid():
             TealInputError,
         ),
         (
-            lambda: GitxnaExpr("Invalid_type", TxnField.application_args, 1),
+            lambda: GitxnaExpr(1, TxnField.application_args, "Invalid_type"),
             TealInputError,
         ),
         (

--- a/pyteal/ast/gitxn_test.py
+++ b/pyteal/ast/gitxn_test.py
@@ -1,4 +1,5 @@
 import pytest
+import typing
 
 from .. import *
 
@@ -7,17 +8,18 @@ teal6Options = CompileOptions(version=6)
 
 
 def test_gitxn_invalid():
-    with pytest.raises(TealInputError):
-        GitxnExpr(0, TxnField.sender).__teal__(teal5Options)
-
-    with pytest.raises(TealInputError):
-        Gitxn[MAX_GROUP_SIZE].sender()
-
-    with pytest.raises(TealInputError):
-        Gitxn[-1].asset_sender()
-
-    with pytest.raises(TealInputError):
-        Gitxn[Bytes("first")].sender()
+    for ctor, e in [
+        (
+            lambda: Gitxn[MAX_GROUP_SIZE],
+            TealInputError,
+        ),
+        (
+            lambda: Gitxn[-1],
+            TealInputError,
+        ),
+    ]:
+        with pytest.raises(e):
+            ctor()
 
 
 def test_gitxn_valid():
@@ -25,17 +27,56 @@ def test_gitxn_valid():
         Gitxn[i].sender()
 
 
-def test_gitxna_invalid():
-    with pytest.raises(TealInputError):
-        GitxnaExpr("Invalid_type", TxnField.application_args, 1).__teal__(teal6Options)
+def test_gitxn_expr_invalid():
+    for f, e in [
+        (
+            lambda: GitxnExpr(Int(1), TxnField.sender),
+            TealInputError,
+        ),
+        (
+            lambda: GitxnExpr(1, TxnField.sender).__teal__(teal5Options),
+            TealInputError,
+        ),
+    ]:
+        with pytest.raises(e):
+            f()
 
-    with pytest.raises(TealInputError):
-        GitxnaExpr(0, TxnField.application_args, "Invalid_type").__teal__(teal6Options)
+
+def test_gitxn_expr_valid():
+    GitxnExpr(1, TxnField.sender).__teal__(teal6Options)
+
+
+def test_gitxna_expr_invalid():
+    for f, e in [
+        (
+            lambda: GitxnaExpr("Invalid_type", TxnField.application_args, 1),
+            TealInputError,
+        ),
+        (
+            lambda: GitxnaExpr("Invalid_type", TxnField.application_args, 1),
+            TealInputError,
+        ),
+        (
+            lambda: GitxnaExpr(0, TxnField.application_args, Assert(Int(1))),
+            TealTypeError,
+        ),
+        (
+            lambda: GitxnaExpr(0, TxnField.application_args, 0).__teal__(teal5Options),
+            TealInputError,
+        ),
+    ]:
+        with pytest.raises(e):
+            f()
 
 
 def test_gitxna_valid():
-    GitxnaExpr(0, TxnField.application_args, 1).__teal__(teal6Options)
-    GitxnaExpr(0, TxnField.application_args, Assert(Int(1))).__teal__(teal6Options)
+    [
+        e.__teal__(teal6Options)
+        for e in [
+            GitxnaExpr(0, TxnField.application_args, 1),
+            GitxnaExpr(0, TxnField.application_args, Int(1)),
+        ]
+    ]
 
 
 # txn_test.py performs additional testing

--- a/pyteal/ast/gitxn_test.py
+++ b/pyteal/ast/gitxn_test.py
@@ -1,5 +1,4 @@
 import pytest
-import typing
 
 from .. import *
 

--- a/pyteal/ast/gtxn.py
+++ b/pyteal/ast/gtxn.py
@@ -14,12 +14,18 @@ if TYPE_CHECKING:
 class GtxnExpr(TxnExpr):
     """An expression that accesses a transaction field from a transaction in the current group."""
 
-    def __init__(self, txnIndex: Union[int, Expr], field: TxnField) -> None:
-        super().__init__(Op.gtxn, "Gtxn", field)
-
+    @staticmethod
+    def __validate_txn_index_or_throw(txnIndex: Union[int, Expr]):
+        if not isinstance(txnIndex, (int, Expr)):
+            raise TealInputError(
+                f"Invalid txnIndex type:  Expected int or Expr, but received {txnIndex}"
+            )
         if isinstance(txnIndex, Expr):
             require_type(txnIndex, TealType.uint64)
 
+    def __init__(self, txnIndex: Union[int, Expr], field: TxnField) -> None:
+        super().__init__(Op.gtxn, "Gtxn", field)
+        self.__validate_txn_index_or_throw(txnIndex)
         self.txnIndex = txnIndex
 
     def __str__(self):

--- a/pyteal/ast/gtxn.py
+++ b/pyteal/ast/gtxn.py
@@ -16,13 +16,11 @@ class GtxnExpr(TxnExpr):
 
     def __init__(self, txnIndex: Union[int, Expr], field: TxnField) -> None:
         super().__init__(Op.gtxn, "Gtxn", field)
+
+        if isinstance(txnIndex, Expr):
+            require_type(txnIndex, TealType.uint64)
+
         self.txnIndex = txnIndex
-
-        def validate_types_or_throw():
-            if isinstance(self.txnIndex, Expr):
-                require_type(txnIndex, TealType.uint64)
-
-        validate_types_or_throw()
 
     def __str__(self):
         return "({} {} {})".format(self.name, self.txnIndex, self.field.arg_name)

--- a/pyteal/ast/gtxn.py
+++ b/pyteal/ast/gtxn.py
@@ -53,12 +53,11 @@ class GtxnaExpr(TxnaExpr):
 
     @staticmethod
     def __validate_txn_index_or_throw(txnIndex: Union[int, Expr]):
-        is_expr = isinstance(txnIndex, Expr)
-        if not (type(txnIndex) is int or is_expr):
+        if not isinstance(txnIndex, (int, Expr)):
             raise TealInputError(
                 f"Invalid txnIndex type:  Expected int or Expr, but received {txnIndex}"
             )
-        if is_expr:
+        if isinstance(txnIndex, Expr):
             require_type(txnIndex, TealType.uint64)
 
     def __init__(

--- a/pyteal/ast/gtxn.py
+++ b/pyteal/ast/gtxn.py
@@ -18,6 +18,12 @@ class GtxnExpr(TxnExpr):
         super().__init__(Op.gtxn, "Gtxn", field)
         self.txnIndex = txnIndex
 
+        def validate_types_or_throw():
+            if isinstance(self.txnIndex, Expr):
+                require_type(txnIndex, TealType.uint64)
+
+        validate_types_or_throw()
+
     def __str__(self):
         return "({} {} {})".format(self.name, self.txnIndex, self.field.arg_name)
 
@@ -52,6 +58,23 @@ class GtxnaExpr(TxnaExpr):
     ) -> None:
         super().__init__(Op.gtxna, Op.gtxnas, "Gtxna", field, index)
         self.txnIndex = txnIndex
+
+        def validate_types_or_throw():
+            def validate_index_or_throw(i):
+                is_expr = isinstance(i, Expr)
+                if not (type(i) is int or is_expr):
+                    raise TealInputError(
+                        "Invalid gtxna syntax with immediate transaction index {}, transaction field {}, array index {}".format(
+                            self.txnIndex, self.field, self.index
+                        )
+                    )
+                if is_expr:
+                    require_type(i, TealType.uint64)
+
+            validate_index_or_throw(self.index)
+            validate_index_or_throw(self.txnIndex)
+
+        validate_types_or_throw()
 
     def __str__(self):
         return "({} {} {} {})".format(

--- a/pyteal/ast/gtxn.py
+++ b/pyteal/ast/gtxn.py
@@ -53,28 +53,22 @@ GtxnExpr.__module__ = "pyteal"
 class GtxnaExpr(TxnaExpr):
     """An expression that accesses a transaction array field from a transaction in the current group."""
 
+    @staticmethod
+    def __validate_txn_index_or_throw(txnIndex: Union[int, Expr]):
+        is_expr = isinstance(txnIndex, Expr)
+        if not (type(txnIndex) is int or is_expr):
+            raise TealInputError(
+                f"Invalid txnIndex type:  Expected int or Expr, but received {txnIndex}"
+            )
+        if is_expr:
+            require_type(txnIndex, TealType.uint64)
+
     def __init__(
         self, txnIndex: Union[int, Expr], field: TxnField, index: Union[int, Expr]
     ) -> None:
         super().__init__(Op.gtxna, Op.gtxnas, "Gtxna", field, index)
+        self.__validate_txn_index_or_throw(txnIndex)
         self.txnIndex = txnIndex
-
-        def validate_types_or_throw():
-            def validate_index_or_throw(i):
-                is_expr = isinstance(i, Expr)
-                if not (type(i) is int or is_expr):
-                    raise TealInputError(
-                        "Invalid gtxna syntax with immediate transaction index {}, transaction field {}, array index {}".format(
-                            self.txnIndex, self.field, self.index
-                        )
-                    )
-                if is_expr:
-                    require_type(i, TealType.uint64)
-
-            validate_index_or_throw(self.index)
-            validate_index_or_throw(self.txnIndex)
-
-        validate_types_or_throw()
 
     def __str__(self):
         return "({} {} {} {})".format(

--- a/pyteal/ast/gtxn.py
+++ b/pyteal/ast/gtxn.py
@@ -11,21 +11,21 @@ if TYPE_CHECKING:
     from ..compiler import CompileOptions
 
 
+def validate_txn_index_or_throw(txnIndex: Union[int, Expr]):
+    if not isinstance(txnIndex, (int, Expr)):
+        raise TealInputError(
+            f"Invalid txnIndex type:  Expected int or Expr, but received {txnIndex}"
+        )
+    if isinstance(txnIndex, Expr):
+        require_type(txnIndex, TealType.uint64)
+
+
 class GtxnExpr(TxnExpr):
     """An expression that accesses a transaction field from a transaction in the current group."""
 
-    @staticmethod
-    def __validate_txn_index_or_throw(txnIndex: Union[int, Expr]):
-        if not isinstance(txnIndex, (int, Expr)):
-            raise TealInputError(
-                f"Invalid txnIndex type:  Expected int or Expr, but received {txnIndex}"
-            )
-        if isinstance(txnIndex, Expr):
-            require_type(txnIndex, TealType.uint64)
-
     def __init__(self, txnIndex: Union[int, Expr], field: TxnField) -> None:
         super().__init__(Op.gtxn, "Gtxn", field)
-        self.__validate_txn_index_or_throw(txnIndex)
+        validate_txn_index_or_throw(txnIndex)
         self.txnIndex = txnIndex
 
     def __str__(self):
@@ -57,20 +57,11 @@ GtxnExpr.__module__ = "pyteal"
 class GtxnaExpr(TxnaExpr):
     """An expression that accesses a transaction array field from a transaction in the current group."""
 
-    @staticmethod
-    def __validate_txn_index_or_throw(txnIndex: Union[int, Expr]):
-        if not isinstance(txnIndex, (int, Expr)):
-            raise TealInputError(
-                f"Invalid txnIndex type:  Expected int or Expr, but received {txnIndex}"
-            )
-        if isinstance(txnIndex, Expr):
-            require_type(txnIndex, TealType.uint64)
-
     def __init__(
         self, txnIndex: Union[int, Expr], field: TxnField, index: Union[int, Expr]
     ) -> None:
         super().__init__(Op.gtxna, Op.gtxnas, "Gtxna", field, index)
-        self.__validate_txn_index_or_throw(txnIndex)
+        validate_txn_index_or_throw(txnIndex)
         self.txnIndex = txnIndex
 
     def __str__(self):

--- a/pyteal/ast/gtxn_test.py
+++ b/pyteal/ast/gtxn_test.py
@@ -2,7 +2,6 @@ import pytest
 
 from .. import *
 
-teal1Options = CompileOptions(version=1)
 teal6Options = CompileOptions(version=6)
 
 
@@ -20,7 +19,6 @@ def test_gtxn_invalid():
 def test_gtxn_expr_invalid():
     for f, e in [
         (lambda: GtxnExpr(Assert(Int(1)), TxnField.sender), TealTypeError),
-        (lambda: GtxnExpr(1, TxnField.sender).__teal__(teal1Options), TealInputError),
     ]:
         with pytest.raises(e):
             f()
@@ -42,10 +40,6 @@ def test_gtxna_expr_invalid():
         (lambda: GtxnaExpr(1, TxnField.assets, "Invalid_type"), TealInputError),
         (lambda: GtxnaExpr(Assert(Int(1)), TxnField.assets, 1), TealTypeError),
         (lambda: GtxnaExpr(1, TxnField.assets, Assert(Int(1))), TealTypeError),
-        (
-            lambda: GtxnaExpr(1, TxnField.assets, 1).__teal__(teal1Options),
-            TealInputError,
-        ),
     ]:
         with pytest.raises(e):
             f()

--- a/pyteal/ast/gtxn_test.py
+++ b/pyteal/ast/gtxn_test.py
@@ -2,19 +2,60 @@ import pytest
 
 from .. import *
 
+teal1Options = CompileOptions(version=1)
+teal6Options = CompileOptions(version=6)
+
 
 def test_gtxn_invalid():
-    with pytest.raises(TealInputError):
-        Gtxn[-1].fee()
+    for f, e in [
+        (lambda: Gtxn[-1], TealInputError),
+        (lambda: Gtxn[MAX_GROUP_SIZE + 1], TealInputError),
+        (lambda: Gtxn[Pop(Int(0))], TealTypeError),
+        (lambda: Gtxn[Bytes("index")], TealTypeError),
+    ]:
+        with pytest.raises(e):
+            f()
 
-    with pytest.raises(TealInputError):
-        Gtxn[MAX_GROUP_SIZE + 1].sender()
 
-    with pytest.raises(TealTypeError):
-        Gtxn[Pop(Int(0))].sender()
+def test_gtxn_expr_invalid():
+    for f, e in [
+        (lambda: GtxnExpr(Assert(Int(1)), TxnField.sender), TealTypeError),
+        (lambda: GtxnExpr(1, TxnField.sender).__teal__(teal1Options), TealInputError),
+    ]:
+        with pytest.raises(e):
+            f()
 
-    with pytest.raises(TealTypeError):
-        Gtxn[Bytes("index")].sender()
+
+def test_gtxn_expr_valid():
+    [
+        e.__teal__(teal6Options)
+        for e in [
+            GtxnExpr(1, TxnField.sender),
+            GtxnExpr(Int(1), TxnField.sender),
+        ]
+    ]
+
+
+def test_gtxna_expr_invalid():
+    for f, e in [
+        (lambda: GtxnaExpr("Invalid_type", TxnField.assets, 1), TealInputError),
+        (lambda: GtxnaExpr(1, TxnField.assets, "Invalid_type"), TealInputError),
+        (lambda: GtxnaExpr(Assert(Int(1)), TxnField.assets, 1), TealTypeError),
+        (lambda: GtxnaExpr(1, TxnField.assets, Assert(Int(1))), TealTypeError),
+        (lambda: GtxnaExpr(1, TxnField.assets, 1).__teal__(teal1Options), TealInputError)
+    ]:
+        with pytest.raises(e):
+            f()
+
+
+def test_gtxna_expr_valid():
+    [
+        e.__teal__(teal6Options)
+        for e in [
+        GtxnaExpr(1, TxnField.assets, 1),
+        GtxnaExpr(Int(1), TxnField.assets, Int(1)),
+        ]
+    ]
 
 
 # txn_test.py performs additional testing

--- a/pyteal/ast/gtxn_test.py
+++ b/pyteal/ast/gtxn_test.py
@@ -42,7 +42,10 @@ def test_gtxna_expr_invalid():
         (lambda: GtxnaExpr(1, TxnField.assets, "Invalid_type"), TealInputError),
         (lambda: GtxnaExpr(Assert(Int(1)), TxnField.assets, 1), TealTypeError),
         (lambda: GtxnaExpr(1, TxnField.assets, Assert(Int(1))), TealTypeError),
-        (lambda: GtxnaExpr(1, TxnField.assets, 1).__teal__(teal1Options), TealInputError)
+        (
+            lambda: GtxnaExpr(1, TxnField.assets, 1).__teal__(teal1Options),
+            TealInputError,
+        ),
     ]:
         with pytest.raises(e):
             f()
@@ -52,8 +55,8 @@ def test_gtxna_expr_valid():
     [
         e.__teal__(teal6Options)
         for e in [
-        GtxnaExpr(1, TxnField.assets, 1),
-        GtxnaExpr(Int(1), TxnField.assets, Int(1)),
+            GtxnaExpr(1, TxnField.assets, 1),
+            GtxnaExpr(Int(1), TxnField.assets, Int(1)),
         ]
     ]
 

--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -161,6 +161,16 @@ TxnExpr.__module__ = "pyteal"
 class TxnaExpr(LeafExpr):
     """An expression that accesses a transaction array field from the current transaction."""
 
+    @staticmethod
+    def __validate_index_or_throw(index: Union[int, Expr]):
+        is_expr = isinstance(index, Expr)
+        if not (type(index) is int or is_expr):
+            raise TealInputError(
+                f"Invalid index type:  Expected int or Expr, but received {index}."
+            )
+        if is_expr:
+            require_type(index, TealType.uint64)
+
     def __init__(
         self,
         staticOp: Op,
@@ -172,6 +182,8 @@ class TxnaExpr(LeafExpr):
         super().__init__()
         if not field.is_array:
             raise TealInputError("Unexpected non-array field: {}".format(field))
+        self.__validate_index_or_throw(index)
+
         self.staticOp = staticOp
         self.dynamicOp = dynamicOp
         self.name = name

--- a/pyteal/ast/txn.py
+++ b/pyteal/ast/txn.py
@@ -163,12 +163,11 @@ class TxnaExpr(LeafExpr):
 
     @staticmethod
     def __validate_index_or_throw(index: Union[int, Expr]):
-        is_expr = isinstance(index, Expr)
-        if not (type(index) is int or is_expr):
+        if not isinstance(index, (int, Expr)):
             raise TealInputError(
                 f"Invalid index type:  Expected int or Expr, but received {index}."
             )
-        if is_expr:
+        if isinstance(index, Expr):
             require_type(index, TealType.uint64)
 
     def __init__(


### PR DESCRIPTION
Moves type validation for `gitxn` and `gitxn` variants from `__teal__()` to `__init__()`.  Where possible, intent is to catch type errors as early as possible.

* Attempts to address https://github.com/algorand/pyteal/pull/193#discussion_r806308236.  Child PR to https://github.com/algorand/pyteal/pull/193.
* Aside:  There's more ground that can be covered with unit tests.  For example, I did _not_ attempt to verify field version constraints.  I'm hoping the PR covers enough ground to be worth merging.